### PR TITLE
Add initial FuseSoC support

### DIFF
--- a/drop.core
+++ b/drop.core
@@ -1,0 +1,29 @@
+CAPI=2:
+
+name : ::drop:0
+
+filesets:
+  rtl:
+    files:
+      - src/project.v : {file_type : verilogSource}
+
+  icebreaker:
+    files:
+      - fpga/icebreaker.v : {file_type : verilogSource}
+      - fpga/icebreaker.pcf : {file_type : PCF}
+
+targets:
+  lint:
+    filesets: [rtl, icebreaker]
+    flow: lint
+    flow_options:
+      tool: verilator
+    toplevel : top
+    
+  icebreaker:
+    filesets: [rtl, icebreaker]
+    flow: icestorm
+    flow_options:
+      icetime_options: [-d, up5k, -mtr]
+      nextpnr_options : [--up5k, --freq, 12]
+    toplevel : top


### PR DESCRIPTION
This adds a core description file for the drop core that exposes targets for linting and building for an icebreaker board.

Quick FuseSoC instructions

 #install FuseSoC
pip install fusesoc

 #Create and enter a new workspace
mkdir workspace && cd workspace

 #Register drop as a library in the workspace
fusesoc library add /path/to/tt08-vga-drop

 #...if repo is available locally or...
fusesoc library add https://github.com/rejunity/tt08-vga-drop
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint drop

 #Build for icebreaker
fusesoc run --target=icebreaker drop

 #List all targets
fusesoc core show drop